### PR TITLE
Fix mailto: URL cannot be opened (urllib.parse.quote parameter)

### DIFF
--- a/test.py
+++ b/test.py
@@ -5,6 +5,7 @@ import time
 import socket
 import concurrent.futures
 import asyncio
+import urllib.parse
 from queue import Queue
 from typing import Tuple, List
 from html import unescape
@@ -95,33 +96,33 @@ for x in possibleTargets:
             victims.append({"target": x, "credentials": retCredentials})
             tmpStr = str(x) + " is a Spectrum Analyser (searching for more endpoints)"
             print(tmpStr)
-            endpointTestStr += "%0D%0A" + tmpStr
+            endpointTestStr += "\r\n" + tmpStr
         else:
             tmpStr = str(x) + " is a websocket endpoint but not the Spectrum Analyzer"
             print(tmpStr)
-            endpointTestStr += "%0D%0A" + tmpStr
+            endpointTestStr += "\r\n" + tmpStr
     except websockets.exceptions.WebSocketException as e:
         tmpStr = str(x) + " is not a websocket endpoint (WebSocketException: " + str(e) + ")"
         print(tmpStr)
-        endpointTestStr += "%0D%0A" + tmpStr
+        endpointTestStr += "\r\n" + tmpStr
         resp=''
     except asyncio.exceptions.TimeoutError as e:
         tmpStr = str(x) + "is a websocket endpoint but not the Spectrum Analyzer (TimeoutError: " + str(e) + ")"
         print(tmpStr)
-        endpointTestStr += "%0D%0A" + tmpStr
+        endpointTestStr += "\r\n" + tmpStr
         resp=''
     except UnicodeDecodeError as e:
         tmpStr = str(x) + "is not a websocket endpoint (UnicodeDecodeError:" + str(e) + ")"
         print(tmpStr)
-        endpointTestStr += "%0D%0A" + tmpStr
+        endpointTestStr += "\r\n" + tmpStr
         resp=''
     except TimeoutError as e:
         tmpStr = str(x) + "is not a websocket endpoint (TimeoutError:", str(e) + ")"
         print(tmpStr)
-        endpointTestStr += "%0D%0A" + tmpStr
+        endpointTestStr += "\r\n" + tmpStr
         resp=''
 
-emailString="Hello Cable Haunt, I have tested my modem for the vulnerability.%0D%0A"
+emailString="Hello Cable Haunt, I have tested my modem for the vulnerability.\r\n"
 vulnerableEndpoints=[]
 nonVulnerableEndpoints=[]
 if victims:
@@ -155,24 +156,24 @@ print("Thank you for testing your modem, do you want to send your results to Cab
 ans=input()
 if ans != "n" and ans != "N":
     print("Who produced your modem? (Leave blank if unknown):")
-    emailString += "%0D%0AManufacturer: " + input()
+    emailString += "\r\nManufacturer: " + input()
     print("What is the model? (Leave blank if unknown):")
-    emailString += "%0D%0AModel: " + input()
+    emailString += "\r\nModel: " + input()
     print("What is the firmware version? (Leave blank if unknown):")
-    emailString += "­%0D%0AFW: " + input()
+    emailString += "­\r\nFW: " + input()
     print("Who is your ISP? (Leave blank if unknown):")
-    emailString += "­%0D%0AISP: " + input()
+    emailString += "­\r\nISP: " + input()
     print("Additional comments (Enter ends comment):")
-    emailString += "­%0D%0AAdditional comments: " + input()
-    emailString += "%0D%0A====================================%0D%0A"
-    emailString += "Vul endpoints:     " + str(vulnerableEndpoints) + "%0D%0A"
-    emailString += "Nonvul endpoints:  " + str(nonVulnerableEndpoints) + "%0D%0A"
-    emailString += "Tested IPs:        " + str(targets) + "%0D%0A"
-    emailString += "Port range:        " + str(portRange) + "%0D%0A"
-    emailString += "Resp check string: " + str(checkString) + "%0D%0A"
-    emailString += "Tested creds:      " + str(credentials) + "%0D%0A"
-    emailString += "Timeout:           " + str(timeoutTime) + "%0D%0A"
-    emailString += "Valid payload:     " + str(validPayload) + "%0D%0A"
-    emailString += "Crash payload:     " + str(crashPayload) + "%0D%0A"
-    emailString += str(endpointTestStr)
-    webbrowser.open("mailto:cablehaunt@lyrebirds.dk?subject=Cable Haunt modem test&body=" + unescape(emailString))
+    emailString += "­\r\nAdditional comments: " + input()
+    emailString += "\r\n====================================\r\n"
+    emailString += "\r\nVul endpoints:     " + str(vulnerableEndpoints)
+    emailString += "\r\nNonvul endpoints:  " + str(nonVulnerableEndpoints)
+    emailString += "\r\nTested IPs:        " + str(targets)
+    emailString += "\r\nPort range:        " + str(portRange)
+    emailString += "\r\nResp check string: " + str(checkString)
+    emailString += "\r\nTested creds:      " + str(credentials)
+    emailString += "\r\nTimeout:           " + str(timeoutTime)
+    emailString += "\r\nValid payload:     " + str(validPayload)
+    emailString += "\r\nCrash payload:     " + str(crashPayload)
+    emailString += "\r\n"+str(endpointTestStr)
+    webbrowser.open("mailto:cablehaunt@lyrebirds.dk?subject=Cable Haunt modem test&body=" + urllib.parse.quote(emailString))


### PR DESCRIPTION
Hi,

While testing the mail sending failed, in attached code I replaced the escape with urllib.parse.quote.
Now it works for me...

Cheers, Jeroen